### PR TITLE
Modif query gv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ radarly-py
 
 
 :Author: Linkfluence
-:Version: 1.0.9
+:Version: 1.1.0
 
 
 

--- a/radarly/__init__.py
+++ b/radarly/__init__.py
@@ -3,7 +3,7 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :Author: Linkfluence
-:Version: 1.0.9
+:Version: 1.1.0
 :Licence: Apache-2.0
 
 .. _official documentation: https://api.linkfluence.com
@@ -53,7 +53,7 @@ from radarly.api import RadarlyApi
 
 
 __title__ = 'radarly'
-__version__ = '1.0.9'
+__version__ = '1.1.0'
 __author__ = 'Linkfluence'
 __url__ = 'https://api.linkfluence.com'
 __licence__ = 'Apache-2.0'

--- a/radarly/api.py
+++ b/radarly/api.py
@@ -206,7 +206,10 @@ class RadarlyApi: # pylint: disable=R0902
 
         self.rates.update(url, res.headers)
 
-        return _decoder(res.json(), blacklist=_BLACKLIST_PATH)
+        if 'inbox/searchQuery.json' in url:
+            return res.json()
+        else:
+            return _decoder(res.json(), blacklist=_BLACKLIST_PATH)
 
     def get(self, url, **kwargs):
         """Shortcut for the ``request`` method with 'GET' as verb.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def readme():
 
 setup(
     name='radarly-py',
-    version='1.0.9',
+    version='1.1.0',
     description="Python client for Radarly API",
     long_description=readme(),
     author='Linkfluence',


### PR DESCRIPTION
Hello Hugo,
J'ai fait la modif sur le client radarly.
J'ai calé un if 'inbox/searchQuery.json' in url dans le file api.py methode request.
Je voulais faire un truc plus propre en rajoutant un chemin précis dans la BLACKLIST qui peut être transmise à la fonction _decode (snake_dict), mais je n'ai pas réussi à trouver le chemin précis à exclure.

Pour info, le return initial envoie le res.json() à la fonction snake_dict (import as _decode dans api.py) qui est dans le module utils/jsonparser.py qui elle meme renvoie la fonction decode_value (dans le meme module)