### PR TITLE
Simple pipeline to deploy radarly-py to PyPi

### DIFF
--- a/.github/actions/build-package/action.yaml
+++ b/.github/actions/build-package/action.yaml
@@ -1,0 +1,14 @@
+name: Build radarly-py package
+description: Build the package using python3
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      shell: bash
+      run: |
+        pip install build
+        python3 -m build

--- a/.github/actions/pypi/action.yaml
+++ b/.github/actions/pypi/action.yaml
@@ -1,0 +1,16 @@
+name: Deploy to pypi
+description: Deploy the package to pypi using twine github action
+
+inputs:
+  token:
+    description: 'PyPi token'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Publish radarly-py to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ inputs.token }}
+        repository_url: https://pypi.org/legacy/

--- a/.github/actions/testpypi/action.yaml
+++ b/.github/actions/testpypi/action.yaml
@@ -1,0 +1,19 @@
+name: Deploy to pypi
+description: Deploy the package to pypi using twine github action
+
+inputs:
+  token:
+    description: 'TestPyPi token'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Publish radarly-py to TestPyPi
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ inputs.token }}
+        repository_url: https://test.pypi.org/legacy/
+        # This setting allows twine to not raise error when a file already exists on the repository
+        # It allow idempotency for this step, it is disabled on the pypi step in order to keep the package consistent.
+        skip_existing: true

--- a/.github/actions/versions/action.yaml
+++ b/.github/actions/versions/action.yaml
@@ -1,0 +1,10 @@
+name: Compare versions
+description: Compare current version with latest version hosted on pypi
+
+runs:
+  using: "composite"
+  steps:
+    - name: Compare version from setup.py and pypi
+      shell: bash
+      run: |
+        bash check-version.sh

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,18 @@
+# Ensure that package can be build and deployed to TestPyPi when a PR is opened
+name: Build and deploy to TestPyPi on pull request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-package
+      - uses: ./.github/actions/testpypi
+        with:
+          token: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/versions
       - uses: ./.github/actions/build-package
       - uses: ./.github/actions/testpypi
         with:

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -1,0 +1,19 @@
+# Ensure that package can be build and deployed before sending it to PyPi
+name: Build and deploy to TestPyPi and PyPi when a push occurs on master
+
+on:
+  push:
+    branches: ['master']
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-package
+      - uses: ./.github/actions/testpypi
+        with:
+          token: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      - uses: ./.github/actions/pypi
+        with:
+          token: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/versions
       - uses: ./.github/actions/build-package
       - uses: ./.github/actions/testpypi
         with:

--- a/check-version.sh
+++ b/check-version.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+CURRENT_VERSION=$(cat setup.py | grep version | sed "s/version='//g" | sed "s/',//g" | tr -d '[:space:]')
+PYPI_LATEST_VERSION=$(curl https://pypi.org/project/radarly-py/  | grep -E -o 'radarly-py [0-9]\.[0-9]\.[0-9][^[:space:]]+' | sed 's/radarly-py //g' | tr -d '[:space:]')
+
+if [[ ${CURRENT_VERSION} == ${PYPI_LATEST_VERSION} ]]
+then
+    echo "current version match pypi version"
+    exit 1
+fi

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def readme():
 
 setup(
     name='radarly-py',
-    version='1.0.9',
+    version='1.0.11',
     description="Python client for Radarly API",
     long_description=readme(),
     author='Linkfluence',


### PR DESCRIPTION
## Feature
Simple CD pipeline to build the radarly-py python package, publish it to **TestPyPi** and then to **PyPi**.
When a PR is opened the package is build and sent to **TestPyPi**, using a flag so that it doesn't trigger errors if the files are already existing on the test repository (in case a PR is opened, closed and then reopened).
When there is a new commit to master, it will go to the previous steps and at the end, if it has been a success, it will be deployed to **PyPi**.

## Github actions structure:
.
└── .github  /
    ├── actions/
    │   ├── build/action.yml
    │   ├── testpypi/action.yml
    │   └── pypi/action.yml
    └── workflows/
        ├── pull-request
        └── push-master

Steps have been splitted accross several actions folder in order to be reusable.
If you need to add more steps and be able to do composition, add your actions on the actions/<your_action>/action.yml and simply call it in the worklow.

## Secret
These secrets need to be added to the repository in order to be able to deploy to **PyPi** and **TestPyPi**:
**TEST_PYPI_API_TOKEN** and **PYPI_API_TOKEN**.
These are the api keys from https://test.pypi.org/ and https://pypi.org/ for the account that own `radarly-py` repository.